### PR TITLE
refactor: Space 상속 전략 조인 -> 단일테이블

### DIFF
--- a/src/main/java/com/example/sabujak/space/entity/Space.java
+++ b/src/main/java/com/example/sabujak/space/entity/Space.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Inheritance(strategy = InheritanceType.JOINED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @Table(name = "space")
 @DiscriminatorColumn
 public abstract class Space {


### PR DESCRIPTION
## Motivation

예약 테이블에 데이터가 가장 많이 쌓이고 조회도 많을것으로 예상
예약 테이블 관련 조회를 할 때 Space도 거의 같이 조회를 할텐데
기존 상속전략의 경우 조인을 한차례 더 수행해 성능을 향상시키기 위해 단일테이블로 수정

## Key Changes

- Change 1
  - a84f1b747072dbb5b8ccfe715d0db9352d933105: 상속 전략 조인 -> 단일테이블
## To reviewers
