### PR TITLE
refactor: #136 추가 과금 방지 위한 문자 전송 주석처리 및 검증 항상 true

### DIFF
--- a/src/main/java/com/example/sabujak/security/service/AuthService.java
+++ b/src/main/java/com/example/sabujak/security/service/AuthService.java
@@ -120,7 +120,7 @@ public class AuthService {
 
         redisService.set(PHONE_CODE_PREFIX + phone.phoneNumber(), verificationCode, (long) PHONE_CODE_EXPIRATION_MILLIS);
 
-        smsService.sendSms(phone.phoneNumber(), createSmsVerificationText(verificationCode));
+        //smsService.sendSms(phone.phoneNumber(), createSmsVerificationText(verificationCode));
     }
 
     private String generateVerifyCode() {
@@ -142,12 +142,12 @@ public class AuthService {
     }
 
     public boolean verifyPhoneCode(VerifyRequestDto.PhoneCode phoneCode) {
-        String codeInRedis = redisService.get(PHONE_CODE_PREFIX + phoneCode.phoneNumber(), String.class)
-                .orElseThrow(() -> new AuthException(EXPIRED_PHONE_CODE));
-
-        if (!codeInRedis.equals(phoneCode.code())) {
-            throw new AuthException(INVALID_PHONE_CODE);
-        }
+//        String codeInRedis = redisService.get(PHONE_CODE_PREFIX + phoneCode.phoneNumber(), String.class)
+//                .orElseThrow(() -> new AuthException(EXPIRED_PHONE_CODE));
+//
+//        if (!codeInRedis.equals(phoneCode.code())) {
+//            throw new AuthException(INVALID_PHONE_CODE);
+//        }
         return true;
     }
 


### PR DESCRIPTION
## Motivation
문자인증 기능은 테스트 완료
문자를 보낼 때 마다 추가 과금이 나오므로 일단은 테스트 통과했으니
문자인증 무조건 true로 통과하게 일단 주석처리

## Key Changes

## To reviewers

