### PR TITLE
bug: LocalTime.MAX 에 .minusSeconds(1) 추가

### DIFF
--- a/src/main/java/com/example/sabujak/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/example/sabujak/reservation/repository/ReservationRepositoryCustom.java
@@ -22,7 +22,6 @@ public interface ReservationRepositoryCustom {
     List<Reservation> findReservationsWithDuration(Member member, LocalDateTime now, int durationStart, int durationEnd);
 
     List<Reservation> findReservationsToday(Member member, LocalDateTime now);
-    Integer countTodayReservation(Member member, LocalDateTime now);
 
     List<Reservation> findAllByRechargingRoomListAndStartTimes(List<RechargingRoom> rechargingRooms, LocalDateTime startAt, LocalDateTime endAt);
 

--- a/src/main/java/com/example/sabujak/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/example/sabujak/reservation/repository/ReservationRepositoryImpl.java
@@ -114,7 +114,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
     @Override
     public List<Reservation> findReservationsWithDuration(Member member, LocalDateTime now, int durationStart, int durationEnd) {
         LocalDateTime startAt = now.plusDays(durationStart).with(LocalTime.MIDNIGHT);
-        LocalDateTime endAt = now.plusDays(durationEnd).with(LocalTime.MAX);
+        LocalDateTime endAt = now.plusDays(durationEnd).with(LocalTime.MAX).minusSeconds(1);
 
         return queryFactory.selectFrom(reservation)
                 .join(reservation.memberReservations, memberReservation)
@@ -149,22 +149,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 
     private BooleanExpression startAfterNowAndBeforeTodayMax(LocalDateTime now) {
         return reservation.reservationStartDateTime.after(now)
-                .and(reservation.reservationStartDateTime.before(now.with(LocalTime.MAX)));
-    }
-
-    @Override
-    public Integer countTodayReservation(Member member, LocalDateTime now) {
-        LocalDateTime startAt = now.with(LocalTime.MIDNIGHT);
-        LocalDateTime endAt = now.with(LocalTime.MAX);
-
-        return Math.toIntExact(queryFactory.select(reservation.count())
-                .from(reservation)
-                .join(reservation.memberReservations, memberReservation)
-                .join(reservation.space, space)
-                .where(memberReservation.member.eq(member),
-                        memberReservation.memberReservationStatus.eq(ReservationStatus.ACCEPTED),
-                        reservation.reservationStartDateTime.between(startAt, endAt))
-                .fetchFirst());
+                .and(reservation.reservationStartDateTime.before(now.with(LocalTime.MAX).minusSeconds(1)));
     }
 
     @Override


### PR DESCRIPTION
## Motivation

db에서 나노세컨드 중복 검증 단계에서 단위 문제가 생기면서 1초를 빼주었는데
LocalTime.MAX 또한
The maximum supported LocalTime, '23:59:59.999999999'. This is the time just before midnight at the end of the day
이런 문제로 LocalTime.MAX 를 사용할 때 1초를 추가적으로 빼줌


## Key Changes

작업한 내용의 주요 변경사항을 자세히 나열하세요

- Change 1
  - 980d4c0916a26473722c3b42e7e31d3cf1d451f9: LocalTime.MAX 에 .minusSeconds(1) 추가 하면서 안쓰는 메소드 삭제

## To reviewers

